### PR TITLE
This change to use message passing addresses issue #23.

### DIFF
--- a/examples/callbacks.rs
+++ b/examples/callbacks.rs
@@ -52,6 +52,7 @@ fn main() {
         window.make_context_current();
 
         while !window.should_close() {
+            window.poll_events();
             glfw::poll_events();
         }
     }

--- a/examples/clipboard.rs
+++ b/examples/clipboard.rs
@@ -33,7 +33,8 @@ fn main() {
         glfw::set_swap_interval(1);
 
         while !window.should_close() {
-            glfw::wait_events();
+            window.poll_events();
+            glfw::poll_events();
         }
     }
 }

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -50,6 +50,7 @@ fn main() {
         }
 
         while !window.should_close() {
+            window.poll_events();
             glfw::poll_events();
         }
     }

--- a/examples/gl-struct.rs
+++ b/examples/gl-struct.rs
@@ -67,6 +67,7 @@ fn main() {
         }
 
         while !window.should_close() {
+            window.poll_events();
             glfw::poll_events();
         }
     }

--- a/examples/manual-init.rs
+++ b/examples/manual-init.rs
@@ -37,6 +37,7 @@ fn main() {
             window.make_context_current();
 
             while !window.should_close() {
+                window.poll_events();
                 glfw::poll_events();
             }
         // Use `finally` to ensure that `glfw::terminate` is called even if a failure occurs

--- a/examples/title.rs
+++ b/examples/title.rs
@@ -33,7 +33,8 @@ fn main() {
         glfw::set_swap_interval(1);
 
         while !window.should_close() {
-            glfw::wait_events();
+            window.poll_events();
+            glfw::poll_events();
         }
     }
 }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -32,6 +32,7 @@ fn main() {
         window.make_context_current();
 
         while !window.should_close() {
+            window.poll_events();
             glfw::poll_events();
         }
     }

--- a/src/glfw.rs
+++ b/src/glfw.rs
@@ -24,6 +24,8 @@
 
 // TODO: Document differences between GLFW and glfw-rs
 
+use std::cast;
+use std::comm::{Port, stream};
 use std::libc::*;
 use std::ptr;
 use std::str;
@@ -43,10 +45,30 @@ pub struct Monitor {
 }
 
 /// A struct that wraps a `*GLFWwindow` handle.
-#[deriving(Eq, IterBytes)]
+//TODO: #[deriving(Eq, IterBytes)]
 pub struct Window {
     ptr: *ffi::GLFWwindow,
     shared: bool,
+    port: Option<Port<WindowEvent>>,
+    data_map: @mut private::WindowData,
+}
+
+/// Events sent for registered window callback functions
+#[deriving(Eq, Clone)]
+pub enum WindowEvent {
+    Pos(int, int),
+    Size(int, int),
+    Close(),
+    Refresh(),
+    Focus(bool),
+    Iconify(bool),
+    FrameBufferSize(int, int),
+    MouseButton(c_int, c_int, c_int),
+    CursorPos(float, float),
+    CursorEnter(bool),
+    Scroll(float, float),
+    Key(c_int, c_int, c_int, c_int),
+    Char(char),
 }
 
 pub type ErrorFun = @fn(error: c_int, description: ~str);
@@ -521,7 +543,7 @@ macro_rules! set_window_callback(
         callback: $ext_fn:ident,
         field:    $data_field:ident
     ) => ({
-        private::WindowDataMap::find_or_insert(self.ptr).$data_field = Some(cbfun);
+        self.data_map.$data_field = Some(cbfun);
         unsafe { ffi::$ll_fn(self.ptr, private::$ext_fn); }
     })
 )
@@ -533,7 +555,8 @@ impl Window {
     ///
     /// The created window wrapped in `Some`, or `None` if an error occurred.
     pub fn create(width: uint, height: uint, title: &str, mode: WindowMode) -> Result<Window,()> {
-        Window::create_shared(width, height, title, mode, &Window { ptr: ptr::null(), shared: false })
+        Window::create_shared(width, height, title, mode, &Window { ptr: ptr::null(), shared: false,
+                port : None, data_map : @mut private::WindowData::new() })
     }
 
     /// Wrapper for `glfwCreateWindow`.
@@ -548,8 +571,37 @@ impl Window {
                     mode.to_ptr(),
                     share.ptr)
             }.to_option().map_default(Err(()),
-                |&ptr| Ok(Window { ptr: ptr::to_unsafe_ptr(ptr), shared: true }))
+                |&ptr| {
+                    let (port , chan) = stream();
+                    let chan = ~chan;
+                    ffi::glfwSetWindowUserPointer(ptr, cast::transmute(chan));
+                    let window = Window { ptr: ptr::to_unsafe_ptr(ptr), shared: true,
+                        port : Some(port), data_map : @mut private::WindowData::new()};
+                    Ok(window)
+                })
         }
+    }
+
+    pub fn poll_events(&self) {
+        do self.port.map |port| {
+            if port.peek() {
+                match port.recv() {
+                    Pos(xpos, ypos) => do self.data_map.pos_fun.map |&cb| { cb(self, xpos, ypos); },
+                    Size(width, height) => do self.data_map.size_fun.map |&cb| { cb(self, width, height); },
+                    Close() => do self.data_map.close_fun.map |&cb| { cb(self); },
+                    Refresh() => do self.data_map.refresh_fun.map |&cb| { cb(self); },
+                    Focus(focused) => do self.data_map.focus_fun.map |&cb| { cb(self, focused); },
+                    Iconify(iconified) => do self.data_map.iconify_fun.map |&cb| { cb(self, iconified); },
+                    FrameBufferSize(width, height) => do self.data_map.framebuffer_size_fun.map |&cb| { cb(self, width, height); },
+                    MouseButton(button, action, mods)=> do self.data_map.mouse_button_fun.map |&cb| { cb(self, button, action, mods); },
+                    CursorPos(xpos, ypos) => do self.data_map.cursor_pos_fun.map |&cb| { cb(self, xpos, ypos); },
+                    CursorEnter(entered) => do self.data_map.cursor_enter_fun.map |&cb| { cb(self, entered); },
+                    Scroll(xpos, ypos) => do self.data_map.scroll_fun.map |&cb| { cb(self, xpos, ypos); },
+                    Key(key, scancode, action, mods) => do self.data_map.key_fun.map |&cb| { cb(self, key, scancode, action, mods); },
+                    Char(character) => do self.data_map.char_fun.map |&cb| { cb(self, character); },
+                };
+            }
+        };
     }
 
     /// Wrapper for `glfwWindowShouldClose`.
@@ -989,6 +1041,7 @@ pub fn get_x11_display() -> *c_void {
     unsafe { ffi::glfwGetX11Display() }
 }
 
+#[unsafe_destructor]
 impl Drop for Window {
     /// Closes the window and removes all associated callbacks.
     ///
@@ -998,8 +1051,28 @@ impl Drop for Window {
         if !self.shared {
             unsafe { ffi::glfwDestroyWindow(self.ptr); }
         }
-        // Remove data from task-local storage
-        private::WindowDataMap::remove(self.ptr);
+
+        if !self.ptr.is_null() {
+            // Free the boxed channel
+            let _chan: ~Chan<WindowEvent> = unsafe { cast::transmute(ffi::glfwGetWindowUserPointer(self.ptr))};
+        }
+
+        // Clear all external callbacks
+        unsafe {
+            self.data_map.pos_fun.map                (|_| ffi::glfwSetWindowPosCallback(self.ptr, ptr::null()));
+            self.data_map.size_fun.map               (|_| ffi::glfwSetWindowSizeCallback(self.ptr, ptr::null()));
+            self.data_map.close_fun.map              (|_| ffi::glfwSetWindowCloseCallback(self.ptr, ptr::null()));
+            self.data_map.refresh_fun.map            (|_| ffi::glfwSetWindowRefreshCallback(self.ptr, ptr::null()));
+            self.data_map.focus_fun.map              (|_| ffi::glfwSetWindowFocusCallback(self.ptr, ptr::null()));
+            self.data_map.iconify_fun.map            (|_| ffi::glfwSetWindowIconifyCallback(self.ptr, ptr::null()));
+            self.data_map.framebuffer_size_fun.map   (|_| ffi::glfwSetFramebufferSizeCallback(self.ptr, ptr::null()));
+            self.data_map.mouse_button_fun.map       (|_| ffi::glfwSetMouseButtonCallback(self.ptr, ptr::null()));
+            self.data_map.cursor_pos_fun.map         (|_| ffi::glfwSetCursorPosCallback(self.ptr, ptr::null()));
+            self.data_map.cursor_enter_fun.map       (|_| ffi::glfwSetCursorEnterCallback(self.ptr, ptr::null()));
+            self.data_map.scroll_fun.map             (|_| ffi::glfwSetScrollCallback(self.ptr, ptr::null()));
+            self.data_map.key_fun.map                (|_| ffi::glfwSetKeyCallback(self.ptr, ptr::null()));
+            self.data_map.char_fun.map               (|_| ffi::glfwSetCharCallback(self.ptr, ptr::null()));
+        }
     }
 }
 

--- a/src/private.rs
+++ b/src/private.rs
@@ -16,10 +16,8 @@
 //! Private functions and items to be used with the high-level library wrapper.
 
 use std::cast;
-use std::hashmap::*;
 use std::libc::*;
 use std::local_data;
-use std::ptr;
 use std::str;
 
 use super::*;
@@ -64,72 +62,6 @@ impl WindowData {
     }
 }
 
-///
-/// A map of window data to be stored in task-local storage.
-///
-pub struct WindowDataMap {
-    priv data_map: HashMap<*ffi::GLFWwindow, @mut WindowData>,
-}
-
-/// Key used for retrieving the map of window data from
-/// task-local storage.
-static data_map_tls_key: local_data::Key<@mut WindowDataMap> = &local_data::Key;
-
-impl WindowDataMap {
-    /// Gets the window data map from task-local storage wrapped in `Some`. If
-    /// no data map is found, `None` is returned.
-    fn get() -> Option<@mut WindowDataMap> {
-        do local_data::get(data_map_tls_key) |opt| {
-            opt.map(|&data_map| *data_map)
-        }
-    }
-
-    /// Gets the window data map from task-local storage. If no data map is
-    /// found, a new one is initialised.
-    fn get_or_init() -> @mut WindowDataMap {
-        match WindowDataMap::get() {
-            Some(data_map) => data_map,
-            None => {
-                let data_map = @mut WindowDataMap { data_map: HashMap::new() };
-                local_data::set(data_map_tls_key, data_map);
-                data_map
-            }
-        }
-    }
-
-    /// Returns a mutable pointer to the window's local data. If no data is
-    /// found, it is initialized and returned.
-    pub fn find_or_insert(window: *ffi::GLFWwindow) -> @mut WindowData {
-        *WindowDataMap::get_or_init().data_map.find_or_insert(window, @mut WindowData::new())
-    }
-
-    /// Clears all external callbacks and removes the window data from the map.
-    /// Returns `true` if the window was present in the map, otherwise `false`.
-    #[fixed_stack_segment] #[inline(never)]
-    pub fn remove(window: *ffi::GLFWwindow) -> bool {
-        do WindowDataMap::get().map |&data_map| {
-            do data_map.data_map.pop(&window).map |&data| {
-                unsafe {
-                    // Clear all external callbacks
-                    data.pos_fun.map                (|_| ffi::glfwSetWindowPosCallback(window, ptr::null()));
-                    data.size_fun.map               (|_| ffi::glfwSetWindowSizeCallback(window, ptr::null()));
-                    data.close_fun.map              (|_| ffi::glfwSetWindowCloseCallback(window, ptr::null()));
-                    data.refresh_fun.map            (|_| ffi::glfwSetWindowRefreshCallback(window, ptr::null()));
-                    data.focus_fun.map              (|_| ffi::glfwSetWindowFocusCallback(window, ptr::null()));
-                    data.iconify_fun.map            (|_| ffi::glfwSetWindowIconifyCallback(window, ptr::null()));
-                    data.framebuffer_size_fun.map   (|_| ffi::glfwSetFramebufferSizeCallback(window, ptr::null()));
-                    data.mouse_button_fun.map       (|_| ffi::glfwSetMouseButtonCallback(window, ptr::null()));
-                    data.cursor_pos_fun.map         (|_| ffi::glfwSetCursorPosCallback(window, ptr::null()));
-                    data.cursor_enter_fun.map       (|_| ffi::glfwSetCursorEnterCallback(window, ptr::null()));
-                    data.scroll_fun.map             (|_| ffi::glfwSetScrollCallback(window, ptr::null()));
-                    data.key_fun.map                (|_| ffi::glfwSetKeyCallback(window, ptr::null()));
-                    data.char_fun.map               (|_| ffi::glfwSetCharCallback(window, ptr::null()));
-                }
-            }
-        }.is_some()
-    }
-}
-
 // Global callbacks
 
 static error_fun_tls_key: local_data::Key<ErrorFun> = &local_data::Key;
@@ -167,37 +99,33 @@ pub fn set_monitor_fun(cbfun: MonitorFun, f: &fn(ffi::GLFWmonitorfun) ) {
 
 // External window callbacks
 
+unsafe fn chan_from_ptr(ptr: *c_void) -> &Chan<WindowEvent> { cast::transmute(ptr) }
+
 macro_rules! window_callback(
-    (fn $name:ident () => $field:ident()) => (
+    (fn $name:ident () => $event:ident()) => (
         pub extern "C" fn $name(window: *ffi::GLFWwindow) {
-            do WindowDataMap::find_or_insert(window).$field.map |&cb| {
-                let window_ = Window { ptr: window, shared: false };
-                cb(&window_);
-                unsafe { cast::forget(window_); }
-            };
+            let chan : &Chan<WindowEvent> = unsafe { chan_from_ptr(ffi::glfwGetWindowUserPointer(window)) };
+            chan.send($event);
         }
     );
-    (fn $name:ident ($($ext_arg:ident: $ext_arg_ty:ty),*) => $field:ident($($arg_conv:expr),*)) => (
+    (fn $name:ident ($($ext_arg:ident: $ext_arg_ty:ty),*) => $event:ident($($arg_conv:expr),*)) => (
         pub extern "C" fn $name(window: *ffi::GLFWwindow $(, $ext_arg: $ext_arg_ty)*) {
-            do WindowDataMap::find_or_insert(window).$field.map |&cb| {
-                let window_ = Window { ptr: window, shared: false };
-                cb(&window_ $(, $arg_conv)*);
-                unsafe { cast::forget(window_); }
-            };
+            let chan : &Chan<WindowEvent> = unsafe { chan_from_ptr(ffi::glfwGetWindowUserPointer(window)) };
+            chan.send($event( $( $arg_conv),* ));
         }
     );
 )
 
-window_callback!(fn window_pos_callback(xpos: c_int, ypos: c_int)                           => pos_fun(xpos as int, ypos as int))
-window_callback!(fn window_size_callback(width: c_int, height: c_int)                       => size_fun(width as int, height as int))
-window_callback!(fn window_close_callback()                                                 => close_fun())
-window_callback!(fn window_refresh_callback()                                               => refresh_fun())
-window_callback!(fn window_focus_callback(focused: c_int)                                   => focus_fun(focused as bool))
-window_callback!(fn window_iconify_callback(iconified: c_int)                               => iconify_fun(iconified as bool))
-window_callback!(fn framebuffer_size_callback(width: c_int, height: c_int)                  => framebuffer_size_fun(width as int, height as int))
-window_callback!(fn mouse_button_callback(button: c_int, action: c_int, mods: c_int)        => mouse_button_fun(button, action, mods))
-window_callback!(fn cursor_pos_callback(xpos: c_double, ypos: c_double)                     => cursor_pos_fun(xpos as float, ypos as float))
-window_callback!(fn cursor_enter_callback(entered: c_int)                                   => cursor_enter_fun(entered as bool))
-window_callback!(fn scroll_callback(xpos: c_double, ypos: c_double)                         => scroll_fun(xpos as float, ypos as float))
-window_callback!(fn key_callback(key: c_int, scancode: c_int, action: c_int, mods: c_int)   => key_fun(key, scancode, action, mods))
-window_callback!(fn char_callback(character: c_uint)                                        => char_fun(character as char))
+window_callback!(fn window_pos_callback(xpos: c_int, ypos: c_int)                           => Pos(xpos as int, ypos as int))
+window_callback!(fn window_size_callback(width: c_int, height: c_int)                       => Size(width as int, height as int))
+window_callback!(fn window_close_callback()                                                 => Close())
+window_callback!(fn window_refresh_callback()                                               => Refresh())
+window_callback!(fn window_focus_callback(focused: c_int)                                   => Focus(focused as bool))
+window_callback!(fn window_iconify_callback(iconified: c_int)                               => Iconify(iconified as bool))
+window_callback!(fn framebuffer_size_callback(width: c_int, height: c_int)                  => FrameBufferSize(width as int, height as int))
+window_callback!(fn mouse_button_callback(button: c_int, action: c_int, mods: c_int)        => MouseButton(button, action, mods))
+window_callback!(fn cursor_pos_callback(xpos: c_double, ypos: c_double)                     => CursorPos(xpos as float, ypos as float))
+window_callback!(fn cursor_enter_callback(entered: c_int)                                   => CursorEnter(entered as bool))
+window_callback!(fn scroll_callback(xpos: c_double, ypos: c_double)                         => Scroll(xpos as float, ypos as float))
+window_callback!(fn key_callback(key: c_int, scancode: c_int, action: c_int, mods: c_int)   => Key(key, scancode, action, mods))
+window_callback!(fn char_callback(character: c_uint)                                        => Char(character as char))


### PR DESCRIPTION
Related to issue #23, we remove the use of task local storage and instead track all 
registered event handlers within the Window struct itself. We also use a channel
for the callbacks from the C code, which requires some changes to the
way that clients poll for events.

This change fixes a crash at shutdown in Servo (and any other application that captures an @mut inside of a closure and registers it with an event handler via glfw-rs today).

In addition to everything you see, I'd really like your opinion on:
1) Similar to Jack's "glfw-refactor," this change requires that clients all call poll_events on the Window. Should that just internally call the global one? Or is there a design with a background per-window task that spins and polls that you would prefer?
2) The move of the WindowData into the Window class broke its #deriving[Eq, IterBytes]. Is this going to cause problems with some client scenarios?
