### PR TITLE
Update Rust

### DIFF
--- a/src/lib/callbacks.rs
+++ b/src/lib/callbacks.rs
@@ -27,7 +27,7 @@ macro_rules! callback(
         let ext_set = $ext_set:expr;
         fn callback($($ext_arg:ident: $ext_arg_ty:ty),*) $call:expr
     ) => (
-        local_data_key!(CALLBACK_KEY: Box<Object<Args>:'static>)
+        local_data_key!(CALLBACK_KEY: Box<Object<Args>+'static>)
 
         type Args = ($($arg_ty),*,);
 
@@ -42,7 +42,7 @@ macro_rules! callback(
         }
 
         pub fn set<UserData: 'static>(f: ::$Callback<UserData>) {
-            CALLBACK_KEY.replace(Some(box f as Box<Object<Args>:'static>));
+            CALLBACK_KEY.replace(Some(box f as Box<Object<Args>+'static>));
             ($ext_set)(Some(callback));
         }
 

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -74,7 +74,7 @@
 extern crate semver;
 extern crate sync;
 extern crate libc;
-#[phase(syntax, link)] extern crate log;
+#[phase(plugin, link)] extern crate log;
 
 use libc::{c_double, c_float, c_int};
 use libc::{c_uint, c_ushort, c_void};
@@ -118,7 +118,7 @@ extern { }
 
 /// Input actions.
 #[repr(C)]
-#[deriving(Clone, Eq, Hash, Show, TotalEq)]
+#[deriving(Clone, PartialEq, Hash, Show, Eq)]
 pub enum Action {
     Release                      = ffi::RELEASE,
     Press                        = ffi::PRESS,
@@ -127,7 +127,7 @@ pub enum Action {
 
 /// Input keys.
 #[repr(C)]
-#[deriving(Clone, Eq, Hash, Show, TotalEq)]
+#[deriving(Clone, PartialEq, Hash, Show, Eq)]
 pub enum Key {
     KeySpace                    = ffi::KEY_SPACE,
     KeyApostrophe               = ffi::KEY_APOSTROPHE,
@@ -255,7 +255,7 @@ pub enum Key {
 /// Mouse buttons. The `MouseButtonLeft`, `MouseButtonRight`, and
 /// `MouseButtonMiddle` aliases are supplied for convenience.
 #[repr(C)]
-#[deriving(Clone, Eq, Hash, Show, TotalEq)]
+#[deriving(Clone, PartialEq, Hash, Show, Eq)]
 pub enum MouseButton {
     /// The left mouse button. A `MouseButtonLeft` alias is provided to improve clarity.
     MouseButton1                = ffi::MOUSE_BUTTON_1,
@@ -299,7 +299,7 @@ pub struct Callback<Fn, UserData> {
 
 /// Tokens corresponding to various error types.
 #[repr(C)]
-#[deriving(Clone, Eq, Hash, Show)]
+#[deriving(Clone, PartialEq, Hash, Show)]
 pub enum Error {
     NotInitialized              = ffi::NOT_INITIALIZED,
     NoCurrentContext            = ffi::NO_CURRENT_CONTEXT,
@@ -337,7 +337,7 @@ pub static LOG_ERRORS: Option<ErrorCallback<()>> =
 
 /// Cursor modes.
 #[repr(C)]
-#[deriving(Clone, Eq, Hash, Show)]
+#[deriving(Clone, PartialEq, Hash, Show)]
 pub enum CursorMode {
     CursorNormal                = ffi::CURSOR_NORMAL,
     CursorHidden                = ffi::CURSOR_HIDDEN,
@@ -377,7 +377,7 @@ pub struct Glfw {
 }
 
 /// An error that might be returned when `glfw::init` is called.
-#[deriving(Eq, Show)]
+#[deriving(PartialEq, Show)]
 pub enum InitError {
     /// The library was already initialized.
     AlreadyInitialized,
@@ -665,7 +665,7 @@ impl Glfw {
     }
 
     /// Sleep until at least one event has been recieved, and then perform the
-    /// equivalent of `Glfw::poll_events`.
+    /// PartialEquivalent of `Glfw::poll_events`.
     ///
     /// Wrapper for `glfwWaitEvents`.
     pub fn wait_events(&self) {
@@ -972,7 +972,7 @@ pub enum WindowHint {
 
 /// Client API tokens.
 #[repr(C)]
-#[deriving(Clone, Eq, Show)]
+#[deriving(Clone, PartialEq, Show)]
 pub enum ClientApi {
     OpenGlApi                   = ffi::OPENGL_API,
     OpenGlEsApi                 = ffi::OPENGL_ES_API,
@@ -980,7 +980,7 @@ pub enum ClientApi {
 
 /// Context robustness tokens.
 #[repr(C)]
-#[deriving(Clone, Eq, Show)]
+#[deriving(Clone, PartialEq, Show)]
 pub enum ContextRobustness {
     NoRobustness                = ffi::NO_ROBUSTNESS,
     NoResetNotification         = ffi::NO_RESET_NOTIFICATION,
@@ -989,7 +989,7 @@ pub enum ContextRobustness {
 
 /// OpenGL profile tokens.
 #[repr(C)]
-#[deriving(Clone, Eq, Show)]
+#[deriving(Clone, PartialEq, Show)]
 pub enum OpenGlProfile {
     OpenGlAnyProfile            = ffi::OPENGL_ANY_PROFILE,
     OpenGlCoreProfile           = ffi::OPENGL_CORE_PROFILE,
@@ -1092,7 +1092,7 @@ impl<'a, Message: Send> Iterator<Message> for FlushedMessages<'a, Message> {
 }
 
 /// A message for notifying a `Window` that a `RenderContext` has been dropped.
-#[deriving(Eq)]
+#[deriving(PartialEq)]
 struct ContextDropped;
 
 /// A struct that wraps a `*GLFWwindow` handle.
@@ -1564,7 +1564,7 @@ pub fn make_context_current(context: Option<&Context>) {
 
 /// Joystick identifier tokens.
 #[repr(C)]
-#[deriving(Clone, Eq, Hash, Show)]
+#[deriving(Clone, PartialEq, Hash, Show)]
 pub enum JoystickId {
     Joystick1       = ffi::JOYSTICK_1,
     Joystick2       = ffi::JOYSTICK_2,


### PR DESCRIPTION
Brings us to [`9f8d2205f0518389993a9b5de6646ba8b14e5a12`](https://github.com/rust-lang/rust/tree/9f8d2205f0518389993a9b5de6646ba8b14e5a12) (June 17)

See https://github.com/mozilla/servo/pull/2677
